### PR TITLE
Crowdtangle /posts ingestion pipeline using apache beam, and SQL schema to store ingested post data

### DIFF
--- a/crowdtangle/convert_big_query_dict_schema_to_sql.py
+++ b/crowdtangle/convert_big_query_dict_schema_to_sql.py
@@ -1,0 +1,87 @@
+"""Tool to convert big query schema in dict format to SQL schema (with CREATE TABLE and COMMENT on
+statements."""
+
+import re
+import crowdtangle_bigquery_schema
+
+big_query_type_to_sql_type = {
+    'STRING': 'character varying',
+    'INT64': 'bigint',
+    'DATETIME': 'timestamp with time zone',
+    'TIMESTAMP': 'timestamp with time zone',
+    'BOOLEAN': 'boolean',
+    'FLOAT': 'double precision',
+    'ACCOUNT': 'FIX_ME_ACCOUNT',
+}
+
+POST_ID_FK_STATEMENT = (
+    'CONSTRAINT post_id_fk FOREIGN KEY (post_id) REFERENCES {schema_name}.posts (id) MATCH SIMPLE ON UPDATE '
+    'NO ACTION ON DELETE NO ACTION')
+ACCOUNT_ID_FK_STATEMENT_FORMAT = (
+    'CONSTRAINT {column_name}_fk FOREIGN KEY ({column_name}) REFERENCES {schema_name}.accounts (id) MATCH SIMPLE ON '
+    'UPDATE NO ACTION ON DELETE NO ACTION')
+LAST_MODIFIED_TIME_COLUMN = (
+    'last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL')
+
+def camel_to_snake(name):
+    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+
+def get_sql_datatype_from_big_query_type(field):
+    return big_query_type_to_sql_type[field['type'].upper()]
+
+def get_column_comment_statement(schema_name, table_name, column_name, comment):
+    return 'COMMENT ON COLUMN {schema_name}.{table_name}.{column_name} IS \'{comment}\';\n'.format(
+        schema_name=schema_name, table_name=table_name, column_name=column_name, comment=comment)
+
+def convert_fields_list_to_create_table_statement(schema_name, table_name, table_comment, fields):
+    column_statements = []
+    column_comments = {}
+    fk_statements = []
+    for field in fields:
+        name = camel_to_snake(field['name'])
+        if name == 'post_id':
+            fk_statements.append(POST_ID_FK_STATEMENT.format(schema_name=schema_name))
+        elif name.endswith('account_id'):
+            fk_statements.append(ACCOUNT_ID_FK_STATEMENT_FORMAT.format(schema_name=schema_name, column_name=name))
+
+        datatype = get_sql_datatype_from_big_query_type(field)
+        if field['mode'] == 'NULLABLE':
+            column_statements.append('{name} {datatype}'.format(name=name, datatype=datatype))
+        elif field['mode'] == 'REQUIRED':
+            column_statements.append('{name} {datatype} NOT NULL'.format(name=name, datatype=datatype))
+        elif field['mode'] == 'PRIMARY_KEY':
+            column_statements.append('{name} {datatype} PRIMARY KEY'.format(name=name, datatype=datatype))
+        else:
+            raise ValueError('Unrecognized mode: %s', field['mode'])
+        if 'description' in field:
+            column_comments[name] = field['description'].replace('\'', '\'\'')
+
+    column_statements.append(LAST_MODIFIED_TIME_COLUMN)
+
+    column_comments_str = ''.join([get_column_comment_statement(schema_name, table_name, column_name, comment)
+                                   for column_name, comment in column_comments.items()])
+    create_statement = 'CREATE TABLE {schema_name}.{table_name} (\n  {column_statements_str}\n);'.format(
+        schema_name=schema_name, table_name=table_name,
+        column_statements_str=',\n  '.join(column_statements + fk_statements))
+    return create_statement, column_comments_str
+
+
+def convert_big_query_dict_schema_to_sql(big_query_schema, schema_name='public'):
+    create_statements = []
+    comment_statements = []
+    for name, sub_schema in big_query_schema.items():
+        table_name = sub_schema['name']
+        table_comment = sub_schema['description']
+        create_statement, comment_statement = convert_fields_list_to_create_table_statement(
+            schema_name, table_name, table_comment, sub_schema['fields'])
+        create_statements.append(create_statement)
+        comment_statements.append(comment_statement)
+
+    print('CREATE SCHEMA', schema_name, ';')
+    print('SELECT pg_catalog.set_config(\'search_path\',', '\'{}\''.format(schema_name), ', false);')
+    print('\n'.join(create_statements + comment_statements))
+
+
+if __name__ == '__main__':
+    convert_big_query_dict_schema_to_sql(crowdtangle_bigquery_schema.CROWDTANGLE_BIGQUERY_SCHEMAS)

--- a/crowdtangle/crowdtangle_bigquery_schema.py
+++ b/crowdtangle/crowdtangle_bigquery_schema.py
@@ -1,0 +1,454 @@
+"""Schema adapted from https://github.com/CrowdTangle/API/wiki/Post. Kept in case we decide to write
+Crowdtangle data to Big Query in the future."""
+CROWDTANGLE_BIGQUERY_SCHEMAS = {
+    'accounts' : {
+            "description": "See account https://github.com/CrowdTangle/API/wiki/Account",
+            "name": "accounts",
+            "type": "RECORD",
+            "mode": "REQUIRED",
+            "fields": [
+                {
+                    "description": "The unique identifier of the account in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform on which the account exists.",
+                    "name": "id",
+                    "type": "INT64",
+                    "mode": "PRIMARY_KEY"
+                },
+                {
+                    "description": "For Facebook only. Options are facebook_page, facebook_profile, facebook_group.",
+                    "name": "accountType",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "The handle or vanity URL of the account.",
+                    "name": "handle",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The name of the account.",
+                    "name": "name",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "The ISO country code of the the country from where the plurality of page administrators operate.",
+                    "name": "pageAdminTopCountry",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The platform on which the account exists. enum (facebook, instagram, reddit)",
+                    "name": "platform",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "The platform's ID for the account. This is not shown for Facebook public users.",
+                    "name": "platformId",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "A URL pointing at the profile image.",
+                    "name": "profileImage",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The number of subscribers/likes/followers the account has. By default, the subscriberCount property will show page Followers (as of January 26, 2021). You can select either Page Likes or Followers in your Dashboard settings. https://help.crowdtangle.com/en/articles/4797890-faq-measuring-followers.",
+                    "name": "subscriberCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "A link to the account on its platform.",
+                    "name": "url",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Whether or not the account is verified by the platform, if supported by the platform. If not supported, will return false.",
+                    "name": "verified",
+                    "type": "BOOLEAN",
+                    "mode": "REQUIRED"
+                }
+            ]
+        },
+    'posts': {
+        "description": "A post object represents a single post from any of the supported platforms (e.g., Facebook, Instagram).",
+        "name": "posts",
+        "type": "RECORD",
+        "mode": "REQUIRED",
+        "fields": [
+        {
+            "description": "format (\"account.id|postExternalId\")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+            "name": "id",
+            "type": "STRING",
+            "mode": "PRIMARY_KEY"
+        },
+        {
+            "description": "See account https://github.com/CrowdTangle/API/wiki/Account",
+            "name": "account_id",
+            "type": "INT64",
+            "mode": "REQUIRED",
+        },
+        {
+            "description": "See account https://github.com/CrowdTangle/API/wiki/Account . This field is only present for Facebook Page posts where there is a sponsoring Page.",
+            "name": "brandedContentSponsor_account_id",
+            "type": "INT64",
+            "mode": "NULLABLE",
+        },
+        {
+            "description": "The user-submitted text on a post.",
+            "name": "message",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "name": "title",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The platform on which the post was posted. E.g., Facebook, Instagram, etc. enum (facebook, instagram, reddit)",
+            "name": "platform",
+            "type": "STRING",
+            "mode": "REQUIRED"
+        },
+        {
+            "description": "The platform's ID for the post.",
+            "name": "platformId",
+            "type": "STRING",
+            "mode": "REQUIRED"
+        },
+        {
+            "description": "The URL to access the post on its platform.",
+            "name": "postUrl",
+            "type": "STRING",
+            "mode": "REQUIRED"
+        },
+        {
+            "description": "The number of subscriber the account had when the post was published. This is in contrast to the subscriberCount found on the account, which represents the current number of subscribers an account has.",
+            "name": "subscriberCount",
+            "type": "INT64",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The type of the post. enum (album, igtv, link, live_video, live_video_complete, live_video_scheduled, native_video, photo, status, video, vine, youtube)",
+            "name": "type",
+            "type": "STRING",
+            "mode": "REQUIRED"
+        },
+        {
+            "description": "The date and time the post was most recently updated in CrowdTangle, which is most often via getting new scores from the platform. Time zone is UTC. \"yyyy-mm-dd hh:mm:ss\")",
+            "name": "updated",
+            "type": "DATETIME",
+            "mode": "REQUIRED"
+        },
+        {
+            "description": "The length of the video in milliseconds.",
+            "name": "videoLengthMS",
+            "type": "INT64",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "string  The text, if it exists, within an image.",
+            "name": "imageText",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The legacy version of the unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+            "name": "legacyId",
+            "type": "INT64",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The caption to a photo, if available.",
+            "name": "caption",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "An external URL that the post links to, if available. (Facebook only)",
+            "name": "link",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "date (\"yyyy‑mm‑dd hh:mm:ss\")  The date and time the post was published. Time zone is UTC.",
+            "name": "date",
+            "type": "TIMESTAMP",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "Further details, if available. Associated with links or images across different platforms.",
+            "name": "description",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The score of a post as measured by the request. E.g. it will represent the overperforming score if the request sortBy specifies overperforming, the interaction rate if the request specifies interaction_rate, etc.",
+            "name": "score",
+            "type": "FLOAT",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "The status of the live video. (\"live\", \"completed\", \"upcoming\")",
+            "name": "liveVideoStatus",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        },
+        {
+            "description": "name of file in GCS",
+            "name": "file_name",
+            "type": "STRING",
+            "mode": "NULLABLE"
+        }
+        ]
+        },
+    'post_statistics_actual':
+            {
+                "description": "Actual performance metrics associated with the post.",
+                "name": "post_statistics_actual",
+                "type": "RECORD",
+                "mode": "REQUIRED",
+                "fields": [
+                    {
+                        "description": "format (\"account.id|postExternalId\")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+                        "name": "post_id",
+                        "type": "STRING",
+                        "mode": "REQUIRED"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "angryCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook, Instagram, Reddit",
+                        "name": "commentCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Instagram",
+                        "name": "favoriteCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "hahaCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "likeCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "loveCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "sadCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "shareCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Reddit",
+                        "name": "upCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "wowCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "thankfulCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    },
+                    {
+                        "description": "Facebook",
+                        "name": "careCount",
+                        "type": "INT64",
+                        "mode": "NULLABLE"
+                    }
+                ]
+        },
+    'post_statistics_expected': {
+                "description": "Expected performance metrics associated with the post.",
+                "name": "post_statistics_expected",
+                "type": "RECORD",
+                "mode": "REQUIRED",
+                "fields": [
+                {
+                    "description": "format (\"account.id|postExternalId\")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+                    "name": "post_id",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "angryCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook, Instagram, Reddit",
+                    "name": "commentCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Instagram",
+                    "name": "favoriteCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "hahaCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "likeCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "loveCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "sadCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "shareCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Reddit",
+                    "name": "upCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "wowCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "thankfulCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "Facebook",
+                    "name": "careCount",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                }
+            ]
+        },
+    'expanded_links': {
+            "description": "List of links as shown to user (original) links that came in the post (which are often shortened), and the expanded links.",
+            "name": "expanded_links",
+            "type": "RECORD",
+            "mode": "REPEATED",
+            "fields": [
+                {
+                    "description": "format (\"account.id|postExternalId\")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+                    "name": "post_id",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "Expanded version of original link",
+                    "name": "expanded",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "original link that came in the post (which are often shortened),",
+                    "name": "original",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+            ]
+        },
+    'media': {
+            "description": "Available media for a post.",
+            "mode": "REPEATED",
+            "name": "media",
+            "type": "RECORD",
+            "fields": [
+                {
+                    "description": "format (\"account.id|postExternalId\")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.",
+                    "name": "post_id",
+                    "type": "STRING",
+                    "mode": "REQUIRED"
+                },
+                {
+                    "description": "The source of the full-sized version of the media. API returns this as |full| but that is a reserved word in postgres",
+                    "name": "url_full",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The source of the media.",
+                    "name": "url",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The width of the media.",
+                    "name": "width",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The height of the media.",
+                    "name": "height",
+                    "type": "INT64",
+                    "mode": "NULLABLE"
+                },
+                {
+                    "description": "The type of the media. enum (photo or video)",
+                    "name": "type",
+                    "type": "STRING",
+                    "mode": "NULLABLE"
+                },
+            ]
+        }
+}

--- a/crowdtangle/fetch_crowdtangle.py
+++ b/crowdtangle/fetch_crowdtangle.py
@@ -1,0 +1,84 @@
+from collections import namedtuple
+import logging
+
+import apache_beam as beam
+from apache_beam.transforms import PTransform
+from minet.crowdtangle import CrowdTangleAPIClient
+from minet.crowdtangle.exceptions import CrowdTangleError
+
+
+FetchCrowdTangleArgs = namedtuple('FetchCrowdTangleArgs', ['start_date',
+                                                           'end_date',
+                                                           'list_ids',
+                                                           'max_results_to_fetch'])
+
+
+class FetchCrowdTangle(PTransform):
+    def __init__(self, *args, api_token=None, crowdtangle_client=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if api_token and crowdtangle_client:
+            raise ValueError('api_token and crowdtangle_client args are mutually exclusive.')
+        self._api_token = api_token
+        self._crowdtangle_client = crowdtangle_client
+
+    def get_crowdtangle_client(self):
+        """Returns the CrowdTangleAPIClient provided in the constructor, or creates a new client
+        from API token stores in GCP secrets manager.
+
+        This is neccessary because CrowdTangleAPIClient hangs when pickled and then depickled (which
+        Apache Beam does sometimes for PTransform objects)
+        """
+        if self._crowdtangle_client:
+            return self._crowdtangle_client
+
+        return CrowdTangleAPIClient(token=self._api_token)
+
+    def fetch(self, input_args):
+        try:
+            start_date = input_args.start_date
+        except KeyError as e:
+            error_msg = "No start date provided. Unable to fetch crowdtangle results"
+            logging.error(error_msg)
+            yield beam.pvalue.TaggedOutput('errors', error_msg)
+            return
+
+        partition_strategy = 500
+        format_val = 'raw'
+        sort_by = 'date'
+        end_date = input_args.end_date
+        list_ids = input_args.list_ids
+        max_results_to_fetch = input_args.max_results_to_fetch
+        query_info_message = (
+            'start_date: {start_date}, end_date: {end_date}, '
+            'partition_strategy: {partition_strategy}, sort_by: {sort_by}, format: {format}, '
+            'max_results_to_fetch: {max_results_to_fetch}, list_ids: {list_ids}'
+            ).format(start_date=start_date, end_date=end_date,
+                     partition_strategy=partition_strategy, sort_by=sort_by, format=format_val,
+                     max_results_to_fetch=max_results_to_fetch, list_ids=list_ids)
+        logging.info('Querying CrowdTangle. %s', query_info_message)
+        num_posts = 0
+        try:
+            crowdtangle_client = self.get_crowdtangle_client()
+            for post in crowdtangle_client.posts(start_date=start_date, end_date=end_date,
+                                                 partition_strategy=partition_strategy,
+                                                 sort_by=sort_by, format=format_val,
+                                                 limit=max_results_to_fetch, list_ids=list_ids):
+                num_posts += 1
+                yield beam.pvalue.TaggedOutput('api_results', post)
+
+            logging.info('CrowdTangle fetch complete. Got %d api_results. query info: %s',
+                         num_posts, query_info_message)
+
+        except CrowdTangleError as e:
+            error_msg = 'Unable to complete fetch, CrowdTangleError: {!r}'.format(e)
+            logging.error(error_msg)
+            yield beam.pvalue.TaggedOutput('errors', error_msg)
+
+
+    def expand(self, p):
+        """Returns tagged output of fetched crowdtangle api_results, and error messages
+        (if encountered)
+        """
+        return (
+            p | "Fetch CrowdTangle results" >> beam.FlatMap(self.fetch).with_outputs('api_results',
+                                                                                     'errors'))

--- a/crowdtangle/process_crowdtangle_posts.py
+++ b/crowdtangle/process_crowdtangle_posts.py
@@ -1,0 +1,182 @@
+from collections import namedtuple
+import datetime
+
+import apache_beam as beam
+
+_ID_KEY = 'id'
+_STATISTICS_KEY = 'statistics'
+_MEDIA_KEY = 'media'
+_EXPANDED_LINKS_KEY = 'expandedLinks'
+_BRANDED_CONTENT_SPONSOR = 'brandedContentSponsor'
+
+EncapsulatedPost = namedtuple('EncapsulatedPost',
+                              ['post',
+                               'account_list',
+                               'statistics_actual',
+                               'statistics_expected',
+                               'expanded_links',
+                               'media_list'])
+PostRecord = namedtuple('PostRecord',
+                        ['id',
+                         'account_id',
+                         'branded_content_sponsor_account_id',
+                         'message',
+                         'title',
+                         'platform',
+                         'platform_id',
+                         'post_url',
+                         'subscriber_count',
+                         'type',
+                         'updated',
+                         'video_length_ms',
+                         'image_text',
+                         'legacy_id',
+                         'caption',
+                         'link',
+                         'date',
+                         'description',
+                         'score',
+                         'live_video_status'])
+AccountRecord = namedtuple('AccountRecord',
+                           ['id',
+                            'account_type',
+                            'handle',
+                            'name',
+                            'page_admin_top_country',
+                            'platform',
+                            'platform_id',
+                            'profile_image',
+                            'subscriber_count',
+                            'url',
+                            'verified',
+                            'updated'])
+StatisticsRecord = namedtuple('StatisticsRecord',
+                              ['post_id',
+                               'updated',
+                               'angry_count',
+                               'comment_count',
+                               'favorite_count',
+                               'haha_count',
+                               'like_count',
+                               'love_count',
+                               'sad_count',
+                               'share_count',
+                               'up_count',
+                               'wow_count',
+                               'thankful_count',
+                               'care_count'])
+ExpandedLinkRecord = namedtuple('ExpandedLinkRecord',
+                                ['post_id',
+                                 'updated',
+                                 'original',
+                                 'expanded'])
+MediaRecord = namedtuple('MediaRecord',
+                         ['post_id',
+                          'updated',
+                          'url_full',
+                          'url',
+                          'width',
+                          'height',
+                          'type'])
+
+class ProcessCrowdTanglePosts(beam.DoFn):
+    """Accepts dict representation of crowdtangle post object, and transforms it EncapsulatedPost.
+    """
+    @staticmethod
+    def make_account_record(account, updated):
+        return AccountRecord(
+            id=account['id'],
+            account_type=account.get('accountType'),
+            handle=account.get('handle'),
+            name=account.get('name'),
+            page_admin_top_country=account.get('pageAdminTopCountry'),
+            platform=account.get('platform'),
+            platform_id=account.get('platformId'),
+            profile_image=account.get('profileImage'),
+            subscriber_count=account.get('subscriberCount'),
+            url=account.get('url'),
+            verified=account.get('verified'),
+            updated=updated)
+
+    @staticmethod
+    def make_statistics_record(statistics, post_id, updated):
+        return StatisticsRecord(
+            post_id=post_id,
+            updated=updated,
+            angry_count=statistics.get('angryCount'),
+            comment_count=statistics.get('commentCount'),
+            favorite_count=statistics.get('favoriteCount'),
+            haha_count=statistics.get('hahaCount'),
+            like_count=statistics.get('likeCount'),
+            love_count=statistics.get('loveCount'),
+            sad_count=statistics.get('sadCount'),
+            share_count=statistics.get('shareCount'),
+            up_count=statistics.get('upCount'),
+            wow_count=statistics.get('wowCount'),
+            thankful_count=statistics.get('thankfulCount'),
+            care_count=statistics.get('careCount'))
+
+    def process(self, item):
+        post_id = item[_ID_KEY]
+        post_updated = datetime.datetime.fromisoformat(
+            item['updated']).replace(tzinfo=datetime.timezone.utc)
+
+        post_record = PostRecord(
+            id=post_id,
+            account_id=item['account']['id'],
+            branded_content_sponsor_account_id=item.get('brandedContentSponsor', {}).get('id'),
+            message=item.get('message'),
+            title=item.get('title'),
+            platform=item.get('platform'),
+            platform_id=item.get('platformId'),
+            post_url=item.get('postUrl'),
+            subscriber_count=item.get('subscriberCount'),
+            type=item.get('type'),
+            updated=post_updated,
+            video_length_ms=item.get('videoLengthMs'),
+            image_text=item.get('imageText'),
+            legacy_id=item.get('legacyId'),
+            caption=item.get('caption'),
+            link=item.get('link'),
+            date=item.get('date'),
+            description=item.get('description'),
+            score=item.get('score'),
+            live_video_status=item.get('liveVideoStatus'))
+
+        account_list = [self.make_account_record(item['account'], post_updated)]
+
+        if _BRANDED_CONTENT_SPONSOR in item:
+            account_list.append(self.make_account_record(item[_BRANDED_CONTENT_SPONSOR],
+                                                         post_updated))
+
+        statistics_actual = None
+        statistics_expected = None
+        if _STATISTICS_KEY in item:
+            statistics = item[_STATISTICS_KEY]
+            if 'actual' in statistics:
+                statistics_actual = self.make_statistics_record(
+                    item[_STATISTICS_KEY]['actual'], post_id=post_id, updated=post_updated)
+            if 'expected' in statistics:
+                statistics_expected = self.make_statistics_record(
+                    item[_STATISTICS_KEY]['expected'], post_id=post_id,
+                    updated=post_updated)
+
+        media_records = []
+        if _MEDIA_KEY in item:
+            media_records = [
+                MediaRecord(post_id=post_id, updated=post_updated, url_full=medium.get('full'),
+                         url=medium.get('url'), width=medium.get('width'),
+                         height=medium.get('height'), type=medium.get('type'))
+                for medium in item[_MEDIA_KEY]]
+
+        expanded_links = []
+        if _EXPANDED_LINKS_KEY in item:
+            expanded_links = [
+                ExpandedLinkRecord(post_id=post_id, updated=post_updated,
+                                   original=link.get('original'), expanded=link.get('expanded'))
+                for link in item[_EXPANDED_LINKS_KEY]]
+
+        yield EncapsulatedPost(post=post_record, account_list=account_list,
+                                 statistics_actual=statistics_actual,
+                                 statistics_expected=statistics_expected,
+                                 expanded_links=expanded_links, media_list=media_records)

--- a/crowdtangle/requirements.txt
+++ b/crowdtangle/requirements.txt
@@ -1,0 +1,4 @@
+setuptools
+apache-beam>=2.28.0
+minet==0.47.0
+psycopg2==2.8.6

--- a/crowdtangle/run_fetch_crowdtangle.py
+++ b/crowdtangle/run_fetch_crowdtangle.py
@@ -1,0 +1,72 @@
+import argparse
+import datetime
+import logging
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.transforms.trigger import AccumulationMode, AfterCount, Repeatedly
+from apache_beam.utils.timestamp import Duration
+
+from crowdtangle import fetch_crowdtangle
+from crowdtangle import process_crowdtangle_posts
+from crowdtangle import write_crowdtangle_results_to_database
+
+import config_utils
+
+def run(argv=None, save_main_session=True):
+    """Main entry point; defines and runs the wordcount pipeline."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--config_path',
+        dest='config_path',
+        required=True,
+        help='Configuration file path')
+    known_args, pipeline_args = parser.parse_known_args(argv)
+
+    # We use the save_main_session option because one or more DoFn's in this
+    # workflow rely on global context (e.g., a module imported at module level).
+    pipeline_options = PipelineOptions(pipeline_args)
+    pipeline_options.view_as(SetupOptions).save_main_session = save_main_session
+
+    config = config_utils.get_config(known_args.config_path)
+    max_results_to_fetch = config['CROWDTANGLE'].getint('MAX_RESULTS_TO_FETCH', None)
+    if 'DAYS_IN_PAST_TO_SYNC' in config['CROWDTANGLE']:
+        start_date = (datetime.date.today() -
+                      datetime.timedelta(days=config['CROWDTANGLE'].getint('DAYS_IN_PAST_TO_SYNC'))
+                      ).isoformat()
+        end_date = None
+    else:
+        start_date = config['CROWDTANGLE'].get('START_DATE')
+        end_date = config['CROWDTANGLE'].get('END_DATE', None)
+    api_token = config['CROWDTANGLE'].get('API_TOKEN')
+
+    fetch_crowdtangle_args = fetch_crowdtangle.FetchCrowdTangleArgs(
+                list_ids=None,
+                start_date=start_date,
+                end_date=end_date,
+                max_results_to_fetch=max_results_to_fetch)
+
+    with beam.Pipeline(options=pipeline_options) as pipeline:
+        results, errors = (
+            pipeline | beam.Create([fetch_crowdtangle_args])
+            | 'Fetch CrowdTangle results' >> fetch_crowdtangle.FetchCrowdTangle(api_token=api_token)
+            )
+
+        processed_results = (
+            results
+            | 'Transform CrowdTangle for SQL' >> beam.ParDo(
+                process_crowdtangle_posts.ProcessCrowdTanglePosts())
+            | 'Batch CrowdTangle results transformed for SQL' >>
+            beam.transforms.util.BatchElements(min_batch_size=10, max_batch_size=500)
+            )
+
+        (processed_results
+         | 'Write processed results to Database' >> beam.ParDo(
+             write_crowdtangle_results_to_database.WriteCrowdTangleResultsToDatabase(
+                     config_utils.get_database_connection_params_from_config(config))))
+
+
+if __name__ == '__main__':
+    config_utils.configure_logger('run_fetch_crowdtangle.log')
+    run()

--- a/crowdtangle/write_crowdtangle_results_to_database.py
+++ b/crowdtangle/write_crowdtangle_results_to_database.py
@@ -1,0 +1,46 @@
+from operator import attrgetter
+import itertools
+import apache_beam as beam
+
+import config_utils
+import db_functions
+
+def dedupe_account_records_by_max_updated_field(account_records):
+    """Return list of account records deduped by ID. If multiple records with the same ID are found
+    the record with the highest/latest |updated| is returned.
+    """
+    account_id_to_latest_updated_record = {}
+    for account in account_records:
+        if account.id in account_id_to_latest_updated_record:
+            account_id_to_latest_updated_record[account.id] = max(
+                account, account_id_to_latest_updated_record[account.id], key=attrgetter('updated'))
+        else:
+            account_id_to_latest_updated_record[account.id] = account
+    return list(account_id_to_latest_updated_record.values())
+
+def get_account_record_list_only_latest_updated_records(pcoll):
+    """Returns list of account records deduped by max updated field."""
+    return dedupe_account_records_by_max_updated_field(
+        itertools.chain.from_iterable(map(attrgetter('account_list'), pcoll)))
+
+class WriteCrowdTangleResultsToDatabase(beam.DoFn):
+    """DoFn that expects iterables of process_crowdtangle_posts.EncapsulatedPost and writes the
+    contained data to database (in order FK relationships reqire).
+    """
+    def __init__(self, database_connection_params, max_batch_size=250):
+        self._database_connection_params = database_connection_params
+        self._max_batch_size = max_batch_size
+
+    def process(self, pcoll):
+        database_connection = config_utils.get_database_connection(self._database_connection_params)
+        with database_connection:
+            db_interface = db_functions.CrowdTangleDBInterface(database_connection)
+            db_interface.upsert_accounts(get_account_record_list_only_latest_updated_records(pcoll))
+            db_interface.upsert_posts(itertools.chain(map(attrgetter('post'), pcoll)))
+            db_interface.upsert_statistics(
+                itertools.chain(map(attrgetter('statistics_actual'), pcoll)),
+                itertools.chain(map(attrgetter('statistics_expected'), pcoll)))
+            db_interface.upsert_expanded_links(itertools.chain.from_iterable(
+                    map(attrgetter('expanded_links'), pcoll)))
+            db_interface.upsert_media(itertools.chain.from_iterable(
+                    map(attrgetter('media_list'), pcoll)))

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -302,3 +302,173 @@ EXECUTE PROCEDURE moddatetime(last_modified_time);
 
 CREATE INDEX ads_page_id_idx ON public.ads USING btree (page_id);
 CREATE INDEX ads_page_id_ad_delivery_start_time_idx ON public.ads USING btree (page_id, ad_delivery_start_time ASC);
+
+-- Crowdtangle database
+
+CREATE TABLE public.accounts (
+  id bigint PRIMARY KEY,
+  account_type character varying NOT NULL,
+  handle character varying,
+  name character varying NOT NULL,
+  page_admin_top_country character varying,
+  platform character varying NOT NULL,
+  platform_id character varying,
+  profile_image character varying,
+  subscriber_count bigint,
+  url character varying,
+  verified boolean NOT NULL,
+  updated timestamp with time zone NOT NULL,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+CREATE TABLE public.posts (
+  id character varying PRIMARY KEY,
+  account_id bigint NOT NULL,
+  branded_content_sponsor_account_id bigint,
+  message character varying,
+  title character varying,
+  platform character varying NOT NULL,
+  platform_id character varying NOT NULL,
+  post_url character varying NOT NULL,
+  subscriber_count bigint,
+  type character varying NOT NULL,
+  updated timestamp with time zone NOT NULL,
+  video_length_ms bigint,
+  image_text character varying,
+  legacy_id bigint,
+  caption character varying,
+  link character varying,
+  date timestamp with time zone,
+  description character varying,
+  score double precision,
+  live_video_status character varying,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT account_id_fk FOREIGN KEY (account_id) REFERENCES public.accounts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT branded_content_sponsor_account_id_fk FOREIGN KEY (branded_content_sponsor_account_id) REFERENCES public.accounts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+CREATE INDEX posts_post_id_updated_idx ON public.posts USING btree (id, updated);
+
+CREATE TABLE public.post_statistics_actual (
+  post_id character varying PRIMARY KEY,
+  updated timestamp with time zone NOT NULL,
+  angry_count bigint,
+  comment_count bigint,
+  favorite_count bigint,
+  haha_count bigint,
+  like_count bigint,
+  love_count bigint,
+  sad_count bigint,
+  share_count bigint,
+  up_count bigint,
+  wow_count bigint,
+  thankful_count bigint,
+  care_count bigint,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT post_id_fk FOREIGN KEY (post_id) REFERENCES public.posts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+CREATE TABLE public.post_statistics_expected (
+  post_id character varying PRIMARY KEY,
+  updated timestamp with time zone NOT NULL,
+  angry_count bigint,
+  comment_count bigint,
+  favorite_count bigint,
+  haha_count bigint,
+  like_count bigint,
+  love_count bigint,
+  sad_count bigint,
+  share_count bigint,
+  up_count bigint,
+  wow_count bigint,
+  thankful_count bigint,
+  care_count bigint,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT post_id_fk FOREIGN KEY (post_id) REFERENCES public.posts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+CREATE TABLE public.expanded_links (
+  post_id character varying NOT NULL,
+  expanded character varying,
+  original character varying,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT post_id_fk FOREIGN KEY (post_id) REFERENCES public.posts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+CREATE TABLE public.media (
+  post_id character varying NOT NULL,
+  url_full character varying,
+  url character varying,
+  width bigint,
+  height bigint,
+  type character varying,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT post_id_fk FOREIGN KEY (post_id) REFERENCES public.posts (id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+COMMENT ON COLUMN public.accounts.id IS 'The unique identifier of the account in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform on which the account exists.';
+COMMENT ON COLUMN public.accounts.account_type IS 'For Facebook only. Options are facebook_page, facebook_profile, facebook_group.';
+COMMENT ON COLUMN public.accounts.handle IS 'The handle or vanity URL of the account.';
+COMMENT ON COLUMN public.accounts.name IS 'The name of the account.';
+COMMENT ON COLUMN public.accounts.page_admin_top_country IS 'The ISO country code of the the country from where the plurality of page administrators operate.';
+COMMENT ON COLUMN public.accounts.platform IS 'The platform on which the account exists. enum (facebook, instagram, reddit)';
+COMMENT ON COLUMN public.accounts.platform_id IS 'The platform''s ID for the account. This is not shown for Facebook public users.';
+COMMENT ON COLUMN public.accounts.profile_image IS 'A URL pointing at the profile image.';
+COMMENT ON COLUMN public.accounts.subscriber_count IS 'The number of subscribers/likes/followers the account has. By default, the subscriberCount property will show page Followers (as of January 26, 2021). You can select either Page Likes or Followers in your Dashboard settings. https://help.crowdtangle.com/en/articles/4797890-faq-measuring-followers.';
+COMMENT ON COLUMN public.accounts.url IS 'A link to the account on its platform.';
+COMMENT ON COLUMN public.accounts.verified IS 'Whether or not the account is verified by the platform, if supported by the platform. If not supported, will return false.';
+
+COMMENT ON COLUMN public.posts.id IS 'format ("account.id|postExternalId")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.posts.account_id IS 'See account https://github.com/CrowdTangle/API/wiki/Account';
+COMMENT ON COLUMN public.posts.branded_content_sponsor_account_id IS 'See account https://github.com/CrowdTangle/API/wiki/Account . This field is only present for Facebook Page posts where there is a sponsoring Page.';
+COMMENT ON COLUMN public.posts.message IS 'The user-submitted text on a post.';
+COMMENT ON COLUMN public.posts.platform IS 'The platform on which the post was posted. E.g., Facebook, Instagram, etc. enum (facebook, instagram, reddit)';
+COMMENT ON COLUMN public.posts.platform_id IS 'The platform''s ID for the post.';
+COMMENT ON COLUMN public.posts.post_url IS 'The URL to access the post on its platform.';
+COMMENT ON COLUMN public.posts.subscriber_count IS 'The number of subscriber the account had when the post was published. This is in contrast to the subscriberCount found on the account, which represents the current number of subscribers an account has.';
+COMMENT ON COLUMN public.posts.type IS 'The type of the post. enum (album, igtv, link, live_video, live_video_complete, live_video_scheduled, native_video, photo, status, video, vine, youtube)';
+COMMENT ON COLUMN public.posts.updated IS 'The date and time the post was most recently updated in CrowdTangle, which is most often via getting new scores from the platform. Time zone is UTC. "yyyy-mm-dd hh:mm:ss")';
+COMMENT ON COLUMN public.posts.video_length_ms IS 'The length of the video in milliseconds.';
+COMMENT ON COLUMN public.posts.image_text IS 'string  The text, if it exists, within an image.';
+COMMENT ON COLUMN public.posts.legacy_id IS 'The legacy version of the unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.posts.caption IS 'The caption to a photo, if available.';
+COMMENT ON COLUMN public.posts.link IS 'An external URL that the post links to, if available. (Facebook only)';
+COMMENT ON COLUMN public.posts.date IS 'date ("yyyy‑mm‑dd hh:mm:ss")  The date and time the post was published. Time zone is UTC.';
+COMMENT ON COLUMN public.posts.description IS 'Further details, if available. Associated with links or images across different platforms.';
+COMMENT ON COLUMN public.posts.score IS 'The score of a post as measured by the request. E.g. it will represent the overperforming score if the request sortBy specifies overperforming, the interaction rate if the request specifies interaction_rate, etc.';
+COMMENT ON COLUMN public.posts.live_video_status IS 'The status of the live video. ("live", "completed", "upcoming")';
+
+COMMENT ON COLUMN public.post_statistics_actual.post_id IS 'format ("account.id|postExternalId")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.post_statistics_actual.angry_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.comment_count IS 'Facebook, Instagram, Reddit';
+COMMENT ON COLUMN public.post_statistics_actual.favorite_count IS 'Instagram';
+COMMENT ON COLUMN public.post_statistics_actual.haha_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.like_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.love_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.sad_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.share_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.up_count IS 'Reddit';
+COMMENT ON COLUMN public.post_statistics_actual.wow_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.thankful_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_actual.care_count IS 'Facebook';
+
+COMMENT ON COLUMN public.post_statistics_expected.post_id IS 'format ("account.id|postExternalId")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.post_statistics_expected.angry_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.comment_count IS 'Facebook, Instagram, Reddit';
+COMMENT ON COLUMN public.post_statistics_expected.favorite_count IS 'Instagram';
+COMMENT ON COLUMN public.post_statistics_expected.haha_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.like_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.love_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.sad_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.share_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.up_count IS 'Reddit';
+COMMENT ON COLUMN public.post_statistics_expected.wow_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.thankful_count IS 'Facebook';
+COMMENT ON COLUMN public.post_statistics_expected.care_count IS 'Facebook';
+
+COMMENT ON COLUMN public.expanded_links.post_id IS 'format ("account.id|postExternalId")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.expanded_links.expanded IS 'Expanded version of original link';
+COMMENT ON COLUMN public.expanded_links.original IS 'original link that came in the post (which are often shortened),';
+
+COMMENT ON COLUMN public.media.post_id IS 'format ("account.id|postExternalId")   The unique identifier of the post in the CrowdTangle system. This ID is specific to CrowdTangle, not the platform from which the post originated.';
+COMMENT ON COLUMN public.media.url_full IS 'The source of the full-sized version of the media. API returns this as |full| but that is a reserved word in postgres';
+COMMENT ON COLUMN public.media.url IS 'The source of the media.';
+COMMENT ON COLUMN public.media.width IS 'The width of the media.';
+COMMENT ON COLUMN public.media.height IS 'The height of the media.';
+COMMENT ON COLUMN public.media.type IS 'The type of the media. enum (photo or video)';
+


### PR DESCRIPTION
This uses Apache Beam which is new to this project, but hopefully worthwhile. Maybe this code should be a different repo or it's own repo, but I put it here to reuse some existing code.

high level description of logic flow:
* Query crowdtangle API (using https://pypi.org/project/minet/)
* For each post
  * Split account info, post data, actual and expected statistics (like counts, etc), expanded links, and media into own structs then transform data as necessary for SQL schema
  * Encapsulate above structs into a single struct
* Batch encapsulated structs
* Process batches, and upsert data to database.
  * topological sort of schema FK relationships is currently Accounts, posts, and then everything else (actual and expected statistics, expanded links, and media). So for each batch all account structs are extracted and sent for upsert, then posts, then everything else
  * post `updated` field is added to Accounts and other structs, and this is used in upsert `ON CONFLICT` where clause to determine if an update should happen (ie only update if `updated` is newer than what is in table). Since this field comes from posts, and multiple posts can have the same account, account records have to be deduped (with only the latest `updated` field as tie breaker) before being sent for upsert (otherwise multiple account records are in the same upsert and `ON CONFLICT` may affect more than one row which causes a database error, and the upsert fails).

`crowdtangle/crowdtangle_bigquery_schema.py` is a python dict big query schema for crowdtangle data kept in case we decide to use big query. `crowdtangle/convert_big_query_dict_schema_to_sql.py` is a script used to create the initial SQL schema from `crowdtangle/crowdtangle_bigquery_schema.py`, but the final schema has changes that were made to accommodate issues discovered while working on this PR.